### PR TITLE
Add more future imports and change package imports to relative instead of absolute

### DIFF
--- a/pyglet_helper/common/__init__.py
+++ b/pyglet_helper/common/__init__.py
@@ -1,6 +1,6 @@
 """pyglet_helper.common contains pyglet_helper libraries common to all
 pyglet_helper.objects objects
 """
-from pyglet_helper.common.materials import RawTexture, ShaderMaterial, \
+from .materials import RawTexture, ShaderMaterial, \
     convert_data, load_tga, shader, TX_TURB3, TX_WOOD, TX_BRICK, TX_RANDOM, \
     LIBRARY

--- a/pyglet_helper/common/materials.py
+++ b/pyglet_helper/common/materials.py
@@ -52,8 +52,8 @@ from numpy import array, reshape, fromstring, ubyte, asarray
 import os.path
 import sys
 
-from pyglet_helper.util.texture import Texture
-from pyglet_helper.objects.material import Material, UNSHADED, EMISSIVE, \
+from ..util.texture import Texture
+from ..objects.material import Material, UNSHADED, EMISSIVE, \
     DIFFUSE, PLASTIC, ROUGH, SHINY, CHROME, ICE, GLASS, BLAZED, SILVER, \
     WOOD, MARBLE, EARTH, BLUEMARBLE, BRICKS
 

--- a/pyglet_helper/common/materials.py
+++ b/pyglet_helper/common/materials.py
@@ -46,6 +46,7 @@ Unstable interfaces:
         raw 2D textures useful only for filling in the textures parameter of
         materials.shader().
 """
+from __future__ import print_function, division, absolute_import
 
 from numpy import array, reshape, fromstring, ubyte, asarray
 import os.path

--- a/pyglet_helper/objects/__init__.py
+++ b/pyglet_helper/objects/__init__.py
@@ -5,24 +5,24 @@ Module containing renderable objects
 """
 from __future__ import absolute_import
 
-from pyglet_helper.objects.material import Material, UNSHADED, EMISSIVE, \
+from .material import Material, UNSHADED, EMISSIVE, \
     DIFFUSE, PLASTIC, ROUGH, SHINY, CHROME, ICE, GLASS, BLAZED, SILVER, \
     WOOD, MARBLE, EARTH, BLUEMARBLE, BRICKS
-from pyglet_helper.objects.array_primitive import ArrayPrimitive
-from pyglet_helper.objects.renderable import Renderable, View
-from pyglet_helper.objects.curve import Curve
-from pyglet_helper.objects.points import Points
-from pyglet_helper.objects.primitive import Primitive
-from pyglet_helper.objects.rectangular import Rectangular
-from pyglet_helper.objects.box import Box
-from pyglet_helper.objects.pyramid import Pyramid
-from pyglet_helper.objects.arrow import Arrow
-from pyglet_helper.objects.axial import Axial
-from pyglet_helper.objects.cone import Cone
-from pyglet_helper.objects.cylinder import Cylinder
-from pyglet_helper.objects.sphere import Sphere
-from pyglet_helper.objects.ellipsoid import Ellipsoid
-from pyglet_helper.objects.light import Light
-from pyglet_helper.objects.ring import Ring
+from .array_primitive import ArrayPrimitive
+from .renderable import Renderable, View
+from .curve import Curve
+from .points import Points
+from .primitive import Primitive
+from .rectangular import Rectangular
+from .box import Box
+from .pyramid import Pyramid
+from .arrow import Arrow
+from .axial import Axial
+from .cone import Cone
+from .cylinder import Cylinder
+from .sphere import Sphere
+from .ellipsoid import Ellipsoid
+from .light import Light
+from .ring import Ring
 
 

--- a/pyglet_helper/objects/array_primitive.py
+++ b/pyglet_helper/objects/array_primitive.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import
+
 try:
     from pyglet.gl import gl
 except Exception as error_msg:

--- a/pyglet_helper/objects/array_primitive.py
+++ b/pyglet_helper/objects/array_primitive.py
@@ -5,7 +5,7 @@ try:
 except Exception as error_msg:
     gl = None
 
-from pyglet_helper.util import RED, Rgb
+from ..util import RED, Rgb
 
 
 class ArrayPrimitive(object):

--- a/pyglet_helper/objects/arrow.py
+++ b/pyglet_helper/objects/arrow.py
@@ -1,6 +1,8 @@
 """
 pyglet_helper.arrow contains an object for drawing an arrow
 """
+from __future__ import print_function, division, absolute_import
+
 try:
     from pyglet.gl import gl
 except Exception as error_msg:

--- a/pyglet_helper/objects/arrow.py
+++ b/pyglet_helper/objects/arrow.py
@@ -7,8 +7,8 @@ try:
     from pyglet.gl import gl
 except Exception as error_msg:
     gl = None
-from pyglet_helper.objects import Box, Material, Primitive, Pyramid
-from pyglet_helper.util import Rgb, Tmatrix, Vector
+from . import Box, Material, Primitive, Pyramid
+from ..util import Rgb, Tmatrix, Vector
 
 
 class Arrow(Primitive):

--- a/pyglet_helper/objects/axial.py
+++ b/pyglet_helper/objects/axial.py
@@ -1,4 +1,6 @@
 """pyglet_helper.axial contains a base class for objects with radial symmetry"""
+from __future__ import print_function, division, absolute_import
+
 from pyglet_helper.objects import Primitive
 from math import pi
 from pyglet_helper.util import Rgb, Tmatrix, Vector

--- a/pyglet_helper/objects/axial.py
+++ b/pyglet_helper/objects/axial.py
@@ -1,10 +1,10 @@
 """pyglet_helper.axial contains a base class for objects with radial symmetry"""
 from __future__ import print_function, division, absolute_import
 
-from pyglet_helper.objects import Primitive
+from . import Primitive
 from math import pi
-from pyglet_helper.util import Rgb, Tmatrix, Vector
-from pyglet_helper.objects.material import Material
+from ..util import Rgb, Tmatrix, Vector
+from .material import Material
 
 
 class Axial(Primitive):

--- a/pyglet_helper/objects/box.py
+++ b/pyglet_helper/objects/box.py
@@ -7,8 +7,8 @@ try:
     import pyglet.gl as gl
 except ImportError:
     gl = None
-from pyglet_helper.objects import Rectangular
-from pyglet_helper.util import Rgb, Vector
+from . import Rectangular
+from ..util import Rgb, Vector
 
 
 

--- a/pyglet_helper/objects/box.py
+++ b/pyglet_helper/objects/box.py
@@ -1,6 +1,8 @@
 """
 pyglet_helper.box contains an object for drawing a box to the screen
 """
+from __future__ import print_function, division, absolute_import
+
 try:
     import pyglet.gl as gl
 except ImportError:

--- a/pyglet_helper/objects/cone.py
+++ b/pyglet_helper/objects/cone.py
@@ -7,8 +7,8 @@ try:
    import pyglet.gl as gl
 except Exception as error_msg:
     gl = None
-from pyglet_helper.objects import Axial
-from pyglet_helper.util import Quadric, Rgb, Vector
+from . import Axial
+from ..util import Quadric, Rgb, Vector
 
 
 class Cone(Axial):

--- a/pyglet_helper/objects/cone.py
+++ b/pyglet_helper/objects/cone.py
@@ -1,6 +1,8 @@
 """
 pyglet_helper.cone contains an object for drawing a cone
 """
+from __future__ import print_function, division, absolute_import
+
 try:
    import pyglet.gl as gl
 except Exception as error_msg:

--- a/pyglet_helper/objects/curve.py
+++ b/pyglet_helper/objects/curve.py
@@ -5,8 +5,8 @@ try:
 except Exception as error_msg:
     gl = None
 
-from pyglet_helper.objects import ArrayPrimitive
-from pyglet_helper.util import Rgb, Vector, make_pointer
+from . import ArrayPrimitive
+from ..util import Rgb, Vector, make_pointer
 from math import pi, cos, sin
 from numpy import zeros
 from ctypes import sizeof, c_uint, c_int, byref

--- a/pyglet_helper/objects/curve.py
+++ b/pyglet_helper/objects/curve.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import
+
 try:
     from pyglet.gl import gl
 except Exception as error_msg:

--- a/pyglet_helper/objects/cylinder.py
+++ b/pyglet_helper/objects/cylinder.py
@@ -7,8 +7,8 @@ try:
     import pyglet.gl as gl
 except Exception as err_msg:
     gl = None
-from pyglet_helper.objects import Axial
-from pyglet_helper.util import Quadric, Rgb, Vector
+from . import Axial
+from ..util import Quadric, Rgb, Vector
 
 
 class Cylinder(Axial):

--- a/pyglet_helper/objects/cylinder.py
+++ b/pyglet_helper/objects/cylinder.py
@@ -1,6 +1,8 @@
 """
 pyglet_helper.cylinder contains an object for drawing a cylinder
 """
+from __future__ import print_function, division, absolute_import
+
 try:
     import pyglet.gl as gl
 except Exception as err_msg:

--- a/pyglet_helper/objects/ellipsoid.py
+++ b/pyglet_helper/objects/ellipsoid.py
@@ -1,6 +1,8 @@
 """
 pyglet_helper.ellipsoid contains an object for drawing an ellipsoid
 """
+from __future__ import print_function, division, absolute_import
+
 from pyglet_helper.objects import Sphere
 from pyglet_helper.util import Rgb, Vector
 

--- a/pyglet_helper/objects/ellipsoid.py
+++ b/pyglet_helper/objects/ellipsoid.py
@@ -3,8 +3,8 @@ pyglet_helper.ellipsoid contains an object for drawing an ellipsoid
 """
 from __future__ import print_function, division, absolute_import
 
-from pyglet_helper.objects import Sphere
-from pyglet_helper.util import Rgb, Vector
+from . import Sphere
+from ..util import Rgb, Vector
 
 
 class Ellipsoid(Sphere):

--- a/pyglet_helper/objects/light.py
+++ b/pyglet_helper/objects/light.py
@@ -1,5 +1,7 @@
 """ pyglet_helper.light contains an object for creating lights
 """
+from __future__ import print_function, division, absolute_import
+
 try:
     import pyglet.gl as gl
 except Exception as error_msg:

--- a/pyglet_helper/objects/light.py
+++ b/pyglet_helper/objects/light.py
@@ -6,9 +6,9 @@ try:
     import pyglet.gl as gl
 except Exception as error_msg:
     gl = None
-from pyglet_helper.objects import Renderable
-from pyglet_helper.util import Rgb, Vector
-from pyglet_helper import GLOBAL_VIEW
+from . import Renderable
+from ..util import Rgb, Vector
+from .. import GLOBAL_VIEW
 
 class Light(Renderable):
     """

--- a/pyglet_helper/objects/material.py
+++ b/pyglet_helper/objects/material.py
@@ -3,7 +3,7 @@ can be applied to objects
 """
 from __future__ import print_function, division, absolute_import
 
-from pyglet_helper.util import ShaderProgram, Texture
+from ..util import ShaderProgram, Texture
 
 
 class Material(object):

--- a/pyglet_helper/objects/material.py
+++ b/pyglet_helper/objects/material.py
@@ -1,6 +1,8 @@
 """ pyglet_helper.material contains an object for describing materials which
 can be applied to objects
 """
+from __future__ import print_function, division, absolute_import
+
 from pyglet_helper.util import ShaderProgram, Texture
 
 

--- a/pyglet_helper/objects/points.py
+++ b/pyglet_helper/objects/points.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import
+
 try:
     from pyglet.gl import gl
 except Exception as error_msg:

--- a/pyglet_helper/objects/points.py
+++ b/pyglet_helper/objects/points.py
@@ -5,8 +5,8 @@ try:
 except Exception as error_msg:
     gl = None
 
-from pyglet_helper.objects import ArrayPrimitive
-from pyglet_helper.util import make_pointer, Rgb, Vector, Vertex, Tmatrix
+from . import ArrayPrimitive
+from ..util import make_pointer, Rgb, Vector, Vertex, Tmatrix
 from enum import Enum
 from ctypes import sizeof, c_float
 

--- a/pyglet_helper/objects/primitive.py
+++ b/pyglet_helper/objects/primitive.py
@@ -2,6 +2,8 @@
 pyglet_helper.primitive contains objects and methods related to drawing all
 geometric shapes
 """
+from __future__ import print_function, division, absolute_import
+
 from pyglet_helper.objects import Material, Renderable, Curve, Points
 from pyglet_helper.util import Rgb, rotation, Tmatrix, Vector
 

--- a/pyglet_helper/objects/primitive.py
+++ b/pyglet_helper/objects/primitive.py
@@ -4,8 +4,8 @@ geometric shapes
 """
 from __future__ import print_function, division, absolute_import
 
-from pyglet_helper.objects import Material, Renderable, Curve, Points
-from pyglet_helper.util import Rgb, rotation, Tmatrix, Vector
+from . import Material, Renderable, Curve, Points
+from ..util import Rgb, rotation, Tmatrix, Vector
 
 # the original primitive class relied on an array_primitive class, however, given that
 #  all objects

--- a/pyglet_helper/objects/pyramid.py
+++ b/pyglet_helper/objects/pyramid.py
@@ -1,6 +1,8 @@
 """
 pyglet_helper.pyramid contains an object for drawing a pyramid
 """
+from __future__ import print_function, division, absolute_import
+
 try:
     import pyglet.gl as gl
 except Exception as error_msg:

--- a/pyglet_helper/objects/pyramid.py
+++ b/pyglet_helper/objects/pyramid.py
@@ -7,8 +7,8 @@ try:
     import pyglet.gl as gl
 except Exception as error_msg:
     gl = None
-from pyglet_helper.objects import Rectangular
-from pyglet_helper.util import Rgb, Tmatrix, Vector
+from . import Rectangular
+from ..util import Rgb, Tmatrix, Vector
 
 
 class Pyramid(Rectangular):

--- a/pyglet_helper/objects/rectangular.py
+++ b/pyglet_helper/objects/rectangular.py
@@ -2,6 +2,7 @@
 pyglet_helper.rectangular contains a base class for drawing objects with
 rectangular symmetry
 """
+from __future__ import print_function, division, absolute_import
 
 from pyglet_helper.objects import Primitive
 from pyglet_helper.util import Rgb, Vector

--- a/pyglet_helper/objects/rectangular.py
+++ b/pyglet_helper/objects/rectangular.py
@@ -4,8 +4,8 @@ rectangular symmetry
 """
 from __future__ import print_function, division, absolute_import
 
-from pyglet_helper.objects import Primitive
-from pyglet_helper.util import Rgb, Vector
+from . import Primitive
+from ..util import Rgb, Vector
 
 
 class Rectangular(Primitive):

--- a/pyglet_helper/objects/renderable.py
+++ b/pyglet_helper/objects/renderable.py
@@ -16,8 +16,8 @@ import pyglet.event as event
 from math import sqrt, pi
 
 
-from pyglet_helper.util import DisplayList, Rgb, Tmatrix, Vector
-from pyglet_helper.objects import Material
+from ..util import DisplayList, Rgb, Tmatrix, Vector
+from . import Material
 
 
 class Renderable(object):

--- a/pyglet_helper/objects/renderable.py
+++ b/pyglet_helper/objects/renderable.py
@@ -1,6 +1,8 @@
 """
 pyglet_helper.renderable contains objects needed to draw all geometric shapes
 """
+from __future__ import print_function, division, absolute_import
+
 try:
     import pyglet.gl as gl
 except ImportError:

--- a/pyglet_helper/objects/ring.py
+++ b/pyglet_helper/objects/ring.py
@@ -5,8 +5,8 @@ try:
     import pyglet.gl as gl
 except Exception as error_msg:
     gl = None
-from pyglet_helper.objects import Axial
-from pyglet_helper.util import Rgb, Tmatrix, Vector
+from . import Axial
+from ..util import Rgb, Tmatrix, Vector
 from math import pi, sin, cos, sqrt
 
 

--- a/pyglet_helper/objects/ring.py
+++ b/pyglet_helper/objects/ring.py
@@ -1,4 +1,6 @@
 """pyglet_helper.ring contains an object for drawing a ring"""
+from __future__ import print_function, division, absolute_import
+
 try:
     import pyglet.gl as gl
 except Exception as error_msg:

--- a/pyglet_helper/objects/sphere.py
+++ b/pyglet_helper/objects/sphere.py
@@ -6,8 +6,8 @@ try:
     import pyglet.gl as gl
 except Exception as error_msg:
     gl = None
-from pyglet_helper.objects import Axial, Material
-from pyglet_helper.util import Quadric, Rgb, Tmatrix, Vector
+from . import Axial, Material
+from ..util import Quadric, Rgb, Tmatrix, Vector
 
 
 class Sphere(Axial):

--- a/pyglet_helper/objects/sphere.py
+++ b/pyglet_helper/objects/sphere.py
@@ -1,5 +1,7 @@
 """ pyglet_helper.sphere contains an object for drawing a sphere
 """
+from __future__ import print_function, division, absolute_import
+
 try:
     import pyglet.gl as gl
 except Exception as error_msg:

--- a/pyglet_helper/test/__init__.py
+++ b/pyglet_helper/test/__init__.py
@@ -3,6 +3,8 @@
 """
 Import the fake gl modules
 """
+from __future__ import print_function, division, absolute_import
+
 from pyglet_helper.test.fake_gl import GL_COLOR_BUFFER_BIT, GL_CULL_FACE, \
     GL_DEPTH_BUFFER_BIT, GL_DEPTH_TEST, GL_LIGHTING, GL_LIGHT0, GL_LIGHT1, \
     GL_LIGHT2, GL_LIGHT3, GL_LIGHT4, GL_LIGHT5, GL_LIGHT6,  GL_LIGHT7, \

--- a/pyglet_helper/test/common_tests/test_materials.py
+++ b/pyglet_helper/test/common_tests/test_materials.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import
+
 from nose.tools import raises
 
 

--- a/pyglet_helper/test/fake_gl.py
+++ b/pyglet_helper/test/fake_gl.py
@@ -2,6 +2,8 @@
 The following file contains definitions for GL functions when pyglet can't
 be used, such as on testing on continuous integration systems.
 """
+from __future__ import print_function, division, absolute_import
+
 from ctypes import c_float, c_double, c_uint
 
 

--- a/pyglet_helper/test/fake_window.py
+++ b/pyglet_helper/test/fake_window.py
@@ -2,7 +2,7 @@
 The following file contains definitions of the window object when pyglet can't
 be used, such as on testing on continuous integration systems.
 """
-
+from __future__ import print_function, division, absolute_import
 
 class Window(object):
     def __init__(self, width=640, height=480):

--- a/pyglet_helper/test/object_tests/test_box.py
+++ b/pyglet_helper/test/object_tests/test_box.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import
+
 from mock import patch
 import pyglet_helper
 

--- a/pyglet_helper/test/object_tests/test_curve.py
+++ b/pyglet_helper/test/object_tests/test_curve.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import
+
 def test_thickline():
     from pyglet_helper.objects import Curve, View
 

--- a/pyglet_helper/test/util_tests/test_linear.py
+++ b/pyglet_helper/test/util_tests/test_linear.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import
+
 from nose.tools import raises
 from mock import patch
 import pyglet_helper.test.fake_gl

--- a/pyglet_helper/util/__init__.py
+++ b/pyglet_helper/util/__init__.py
@@ -1,6 +1,8 @@
 """ pyglet_helper.util contains objects useful to creating materials and
 geometric shapes
 """
+from __future__ import print_function, division, absolute_import
+
 from pyglet_helper.util.color import BLUE, RED, GREEN, GRAY, MAGENTA, YELLOW, \
     CYAN, ORANGE, BLACK, PURPLE, WHITE
 from pyglet_helper.util.display_list import DisplayList

--- a/pyglet_helper/util/__init__.py
+++ b/pyglet_helper/util/__init__.py
@@ -3,14 +3,14 @@ geometric shapes
 """
 from __future__ import print_function, division, absolute_import
 
-from pyglet_helper.util.color import BLUE, RED, GREEN, GRAY, MAGENTA, YELLOW, \
+from .color import BLUE, RED, GREEN, GRAY, MAGENTA, YELLOW, \
     CYAN, ORANGE, BLACK, PURPLE, WHITE
-from pyglet_helper.util.display_list import DisplayList
-from pyglet_helper.util.quadric import DrawingStyle, NormalStyle, \
+from .display_list import DisplayList
+from .quadric import DrawingStyle, NormalStyle, \
     Orientation, Quadric
-from pyglet_helper.util.rgba import Rgba, Rgb
-from pyglet_helper.util.shader_program import ShaderProgram, UseShaderProgram
-from pyglet_helper.util.texture import Texture
-from pyglet_helper.util.linear import Vector, Vertex, Tmatrix, rotation
-from pyglet_helper.util.ctypes_util import make_pointer
+from .rgba import Rgba, Rgb
+from .shader_program import ShaderProgram, UseShaderProgram
+from .texture import Texture
+from .linear import Vector, Vertex, Tmatrix, rotation
+from .ctypes_util import make_pointer
 

--- a/pyglet_helper/util/color.py
+++ b/pyglet_helper/util/color.py
@@ -1,5 +1,7 @@
 """ pyglet_helper.util.color defines a few standard colors
 """
+from __future__ import print_function, division, absolute_import
+
 from pyglet_helper.util.rgba import Rgb
 
 BLUE = Rgb(red=0.0, green=0.0, blue=1.0)

--- a/pyglet_helper/util/color.py
+++ b/pyglet_helper/util/color.py
@@ -2,7 +2,7 @@
 """
 from __future__ import print_function, division, absolute_import
 
-from pyglet_helper.util.rgba import Rgb
+from .rgba import Rgb
 
 BLUE = Rgb(red=0.0, green=0.0, blue=1.0)
 RED = Rgb(red=1.0, green=0.0, blue=0.0)

--- a/pyglet_helper/util/ctypes_util.py
+++ b/pyglet_helper/util/ctypes_util.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, division, absolute_import
+
 from ctypes import c_float, c_long
 
 

--- a/pyglet_helper/util/quadric.py
+++ b/pyglet_helper/util/quadric.py
@@ -2,6 +2,8 @@
 quadric-type
 geometric shapes
 """
+from __future__ import print_function, division, absolute_import
+
 try:
     import pyglet.gl as gl
 except ImportError:

--- a/pyglet_helper/util/rgba.py
+++ b/pyglet_helper/util/rgba.py
@@ -1,6 +1,8 @@
 """
 pyglet_helper.util.rgba contains object to describe colors
 """
+from __future__ import print_function, division, absolute_import
+
 try:
     import pyglet.gl as gl
 except Exception as error_msg:

--- a/pyglet_helper/util/shader_program.py
+++ b/pyglet_helper/util/shader_program.py
@@ -1,6 +1,8 @@
 """ pyglet_helper.util.shader_program contains objects for creating programs to
 describe how the light treats the object
 """
+from __future__ import print_function, division, absolute_import
+
 try:
     import pyglet.gl as gl
 except ImportError:


### PR DESCRIPTION
I left the imports in the tests alone; I'm not that familiar with nose and wasn't sure whether they should be absolute or relative.

There are a couple of rotation tests that fail locally: `test_linear.test_rotation_with_origin` and `test_linear.test_vector_rotate`, but they also fail before these changes. I think the underlying issue with those tests may be in `TMatrix.w_column`, where the default values for that column are set to 1 instead of 0...but it was getting too late to really think about rotation matrices 😀
